### PR TITLE
Use <std-switch>, and other cleanups

### DIFF
--- a/demo/loadmore.html
+++ b/demo/loadmore.html
@@ -1,36 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <title>Virtual Scoller Demo - Load more</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+  <title>Virtual Scoller Demo - Load more</title>
 
-  <style>
-    body {
-      font-family: Roboto, Helvetica, sans-serif;
-      max-width: 600px;
-      height: 100vh;
-      margin: 0px auto;
-      display: flex;
-      flex-direction: column;
+  <link rel="stylesheet" href="styles.css">
+
+  <script type="importmap">
+  {
+    "imports": {
+      "./std-switch-polyfill/std-switch.mjs": [
+        "std:elements/switch",
+        "./std-switch-polyfill/std-switch.mjs"
+      ]
     }
+  }
+  </script>
 
-    virtual-scroller {
-      flex: 1;
-      margin: 10px 0;
-      border-top: 2px solid #eee;
-      border-bottom: 2px solid #eee;
-    }
-
-    contact-element,
-    button {
-      height: 80px;
-    }
-  </style>
-</head>
-
-<body>
   <confirm-features></confirm-features>
 
   <p>Demonstrates the ease-of-use of the <code>&lt;virtual-scroller&gt;</code> element
@@ -43,13 +29,18 @@
     to cause the fetch to start before the place-holder element is visible.
   </p>
 
-  <div>
-    <button id=swapButton>switch virtual-scroller &lt;-&gt; div</button>
-  </div>
+  <fieldset>
+    <label>
+      <std-switch id="useVirtualScroller" on></std-switch>
+      Use <code>&lt;virtual-scroller&gt;</code> instead of <code>&lt;div&gt;</code>
+    </label>
+  </fieldset>
+
 
   <virtual-scroller id=scroller></virtual-scroller>
 
   <script type="module">
+    import './std-switch-polyfill/std-switch.mjs';
     import './util/confirm-features.mjs';
     import './contacts/contact-element.mjs';
     import { ContactDataSource } from './contacts/contact-data-source.mjs';
@@ -63,7 +54,7 @@
 
     const loader = document.createElement('div');
 
-    const scroller = document.getElementById('scroller');
+    let scroller = document.getElementById('scroller');
     scroller.appendChild(loader);
 
     async function loadMore() {
@@ -91,14 +82,15 @@
     const observer = new IntersectionObserver(loadMore);
     observer.observe(loader);
 
+    const useVirtualScroller = document.querySelector('#useVirtualScroller');
+
+    document.querySelector('confirm-features').associateSwitch(useVirtualScroller);
+
     function swapScroller() {
-      const swapInLocalName = scroller.localName === "div" ? "virtual-scroller" : "div";
+      const swapInLocalName = useVirtualScroller.on ? "virtual-scroller" : "div";
       const swapIn = document.createElement(swapInLocalName);
       util.swapElement(scroller, swapIn);
+      scroller = document.getElementById('scroller');
     }
-    document.querySelector('#swapButton')
-        .addEventListener('click', swapScroller);
+    useVirtualScroller.addEventListener('change', swapScroller);
   </script>
-</body>
-
-</html>

--- a/demo/std-switch-polyfill/README.md
+++ b/demo/std-switch-polyfill/README.md
@@ -1,0 +1,5 @@
+# `<std-switch>` polyfill
+
+This is a work-in-progress polyfill for the proposed [`<std-switch>` element](https://github.com/tkent-google/std-switch).
+
+Eventually it will move to its own repository and be included in this one via npm. For now it is directly included in the `<virtual-scroller>` demos source tree so we can use it there.

--- a/demo/std-switch-polyfill/element-internals-shim.mjs
+++ b/demo/std-switch-polyfill/element-internals-shim.mjs
@@ -1,0 +1,133 @@
+// This class emulates the relevant parts of ElementInternals for us
+export default class ElementInternalsShim {
+  constructor(element) {
+    this._element = element;
+    if (element.attachInternals) {
+      this._internals = element.attachInternals();
+    }
+
+    this._tabIndexBeforeDisabling = '0';
+  }
+
+  handleDisabledChanged(disabled) {
+    if (this._internals) {
+      // No need to do anything; the browser will take care of this for us.
+      return;
+    }
+
+    this._element.setAttribute('aria-disabled', disabled);
+
+    if (disabled) {
+      this._tabIndexBeforeDisabling = this._element.getAttribute('tabindex');
+
+      // This isn't as good as really disabling it, because it doesn't prevent click-focusability.
+      // But it's the best we can do.
+      this._element.setAttribute('tabindex', '-1');
+    } else if (this._element.getAttribute('tabindex') === '-1') {
+      if (this._tabIndexBeforeDisabling !== null) {
+        this._element.setAttribute('tabindex', this._tabIndexBeforeDisabling);
+      } else {
+        this._element.removeAttribute('tabindex');
+      }
+    }
+  }
+
+  setRole(role) {
+    if (this._internals && 'role' in this._internals) {
+      this._internals.role = role;
+    } else {
+      // We want to let non-default roles override.
+      if (!this._element.hasAttribute('role')) {
+        this._element.setAttribute('role', role);
+      }
+    }
+  }
+
+  setARIAChecked(value) {
+    if (this._internals && 'ariaChecked' in this._internals) {
+      this._internals.ariaChecked = value;
+    } else {
+      // Unlike role, we're not concerned with preserving overriden aria-checked values.
+      this._element.setAttribute('aria-checked', value);
+    }
+  }
+
+  makeFocusable() {
+    // We don't know what the ElementInternals version of this will look like yet.
+
+    if (!this._element.hasAttribute('tabindex')) {
+      this._element.setAttribute('tabindex', '0');
+    }
+  }
+
+  setFormValue(value) {
+    // TODO
+  }
+
+  get form() {
+    if (this._internals && 'form' in this._internals) {
+      return this._internals.form;
+    }
+
+    // TODO
+    return null;
+  }
+  get willValidate() {
+    if (this._internals && 'willValidate' in this._internals) {
+      return this._internals.willValidate;
+    }
+
+    // TODO
+    return this;
+  }
+  get validity() {
+    if (this._internals && 'validity' in this._internals) {
+      return this._internals.validity;
+    }
+
+    // TODO
+    return null;
+  }
+  get validationMessage() {
+    if (this._internals && 'validationMessage' in this._internals) {
+      return this._internals.validationMessage;
+    }
+
+    // TODO
+    return "";
+  }
+  get labels() {
+    if (this._internals && 'labels' in this._internals) {
+      return this._internals.labels;
+    }
+
+    // TODO
+    return [];
+  }
+  checkValidity() {
+    if (this._internals && 'checkValidity' in this._internals) {
+      return this._internals.checkValidity();
+    }
+
+    // TODO
+  }
+  reportValidity() {
+    if (this._internals && 'reportValidity' in this._internals) {
+      return this._internals.reportValidity();
+    }
+
+    // TODO
+  }
+  setCustomValidity(error) {
+    if (error === undefined) {
+      throw new TypeError('Too few arguments');
+    }
+
+    if (this._internals && 'setValidity' in this._internals) {
+      this._internals.setValidity({customError: true}, error);
+      return;
+    }
+
+    // TODO
+  }
+}

--- a/demo/std-switch-polyfill/std-switch.mjs
+++ b/demo/std-switch-polyfill/std-switch.mjs
@@ -1,0 +1,206 @@
+import * as style from './style.mjs';
+import {SwitchTrack} from './track.mjs';
+import ElementInternalsShim from './element-internals-shim.mjs';
+
+const generateStyleSheet = style.styleSheetFactory();
+
+export class StdSwitchElement extends HTMLElement {
+  static get formAssociated() {
+    return true;
+  }
+  static get observedAttributes() {
+    return ['on', 'disabled'];
+  }
+
+  constructor() {
+    super();
+    if (new.target !== StdSwitchElement) {
+      throw new TypeError(
+          'Illegal constructor: StdSwitchElement is not ' +
+          'extensible for now');
+    }
+    this._inUserAction = false;
+    this._initializeDOM();
+
+    this._internalsShim = new ElementInternalsShim(this);
+
+    this.addEventListener('click', () => this._onClick());
+    this.addEventListener('keypress', e => this._onKeyPress(e));
+  }
+
+  // TODO: make this work for the shim somehow
+  formResetCallback() {
+    this.on = this.defaultOn;
+  }
+
+  attributeChangedCallback(attrName, oldValue, newValue) {
+    switch (attrName) {
+      case 'on': {
+        const on = newValue !== null;
+
+        this._track.value = on;
+        this._internalsShim.setFormValue(on ? 'on' : 'off');
+        this._internalsShim.setARIAChecked(on ? 'true': 'false');
+
+        if (!this._inUserAction) {
+          for (const element of this._containerElement.querySelectorAll('*')) {
+            style.unmarkTransition(element);
+          }
+        }
+
+        break;
+      }
+
+      case 'disabled': {
+        this._internalsShim.handleDisabledChanged(newValue !== null);
+
+        break;
+      }
+    }
+  }
+
+  connectedCallback() {
+    this._internalsShim.makeFocusable();
+    this._internalsShim.setRole('switch');
+  }
+
+  _initializeDOM() {
+    const factory = this.ownerDocument;
+    const root = this.attachShadow({mode: 'closed'});
+    this._containerElement = factory.createElement('span');
+    this._containerElement.id = 'container';
+    // Shadow elements should be invisible for a11y technologies.
+    this._containerElement.setAttribute('aria-hidden', 'true');
+    root.appendChild(this._containerElement);
+
+    this._track = new SwitchTrack(factory);
+    this._containerElement.appendChild(this._track.element);
+    this._track.value = this.on;
+
+    const thumbElement =
+        this._containerElement.appendChild(factory.createElement('span'));
+    thumbElement.id = 'thumb';
+
+    if ('part' in thumbElement) {
+      thumbElement.part.add('thumb');
+    }
+
+    root.append(generateStyleSheet());
+  }
+
+  _onClick() {
+    // Only necessary for the polyfill; if form-associated custom elements work
+    // then the event will never reach us.
+    if (this.disabled) {
+      return;
+    }
+
+    for (const element of this._containerElement.querySelectorAll('*')) {
+      style.markTransition(element);
+    }
+    this._inUserAction = true;
+    try {
+      this.on = !this.on;
+    } finally {
+      this._inUserAction = false;
+    }
+    this.dispatchEvent(new Event('input', {bubbles: true}));
+    this.dispatchEvent(new Event('change', {bubbles: true}));
+  }
+
+  _onKeyPress(event) {
+    // Only necessary for the polyfill; if form-associated custom elements work
+    // then the event will never reach us.
+    if (this.disabled) {
+      return;
+    }
+
+    if (event.code === 'Space') {
+      // Do not scroll the page.
+      event.preventDefault();
+      this._onClick(event);
+    }
+  }
+
+  get type() {
+    return 'std-switch';
+  }
+  get form() {
+    return this._internalsShim.form;
+  }
+  get willValidate() {
+    return this._internalsShim.willValidate;
+  }
+  get validity() {
+    return this._internalsShim.validity;
+  }
+  get validationMessage() {
+    return this._internalsShim.validationMessage;
+  }
+  get labels() {
+    return this._internalsShim.labels;
+  }
+  checkValidity() {
+    return this._internalsShim.checkValidity();
+  }
+  reportValidity() {
+    return this._internalsShim.reportValidity();
+  }
+  setCustomValidity(error) {
+    this._internalsShim.setCustomValidity(error);
+  }
+
+  get name() {
+    const value = this.getAttribute('name');
+    return value === null ? '' : value;
+  }
+  set name(value) {
+    this.setAttribute('name', value);
+  }
+
+  get disabled() {
+    return this.hasAttribute('disabled');
+  }
+  set disabled(value) {
+    this.toggleAttribute('disabled', Boolean(value));
+  }
+
+  get on() {
+    return this.hasAttribute('on');
+  }
+  set on(value) {
+    this.toggleAttribute('on', Boolean(value));
+  }
+
+  get defaultOn() {
+    return this.hasAttribute('defaulton');
+  }
+  set defaultOn(value) {
+    this.toggleAttribute('defaulton', Boolean(value));
+  }
+}
+
+Object.defineProperty(StdSwitchElement.prototype, Symbol.toStringTag, {
+  configurable: true,
+  enumerable: false,
+  value: 'StdSwitchElement',
+  writable: false,
+});
+
+Object.defineProperty(StdSwitchElement.prototype, 'on', {enumerable: true});
+Object.defineProperty(StdSwitchElement.prototype, 'defaultOn', {enumerable: true});
+Object.defineProperty(StdSwitchElement.prototype, 'form', {enumerable: true});
+Object.defineProperty(StdSwitchElement.prototype, 'willValidate', {enumerable: true});
+Object.defineProperty(StdSwitchElement.prototype, 'validity', {enumerable: true});
+Object.defineProperty(StdSwitchElement.prototype, 'validationMessage', {enumerable: true});
+Object.defineProperty(StdSwitchElement.prototype, 'labels', {enumerable: true});
+Object.defineProperty(StdSwitchElement.prototype, 'checkValidity', {enumerable: true});
+Object.defineProperty(StdSwitchElement.prototype, 'reportValidity', {enumerable: true});
+Object.defineProperty(StdSwitchElement.prototype, 'setCustomValidity', {enumerable: true});
+
+customElements.define('std-switch', StdSwitchElement);
+delete StdSwitchElement.formAssociated;
+delete StdSwitchElement.observedAttributes;
+delete StdSwitchElement.prototype.attributeChangedCallback;
+delete StdSwitchElement.prototype.connectedCallback;
+delete StdSwitchElement.prototype.formResetCallback;

--- a/demo/std-switch-polyfill/style.mjs
+++ b/demo/std-switch-polyfill/style.mjs
@@ -1,0 +1,156 @@
+// Style constant values.
+const COLOR_ON = '#0077FF';
+const TRACK_RADIUS = '13px';
+const TRACK_BORDER_WIDTH = '2px';
+const THUMB_HEIGHT = '22px';
+const THUMB_WIDTH = '22px';
+const THUMB_MARGIN_START = '2px';
+const THUMB_MARGIN_END = '2px';
+
+// Returns a function returning a HTMLLinkElement.
+export function styleSheetFactory() {
+  let url;
+  return () => {
+    if (!url) {
+      url = URL.createObjectURL(new Blob([`
+:host {
+  block-size: 26px;
+  border: none;
+  box-sizing: border-box;
+  display: inline-block;
+  inline-size: 54px;
+  user-select: none;
+  vertical-align: middle;
+}
+
+#container {
+  align-items: center;
+  block-size: 100%;
+  display: inline-flex;
+  inline-size: 100%;
+}
+
+#thumb {
+  background: white;
+  block-size: ${THUMB_HEIGHT};
+  border-radius: calc(${THUMB_HEIGHT} / 2);
+  border: 1px solid black;
+  box-sizing: border-box;
+  display: inline-block;
+  margin-inline-start: calc(-100% + ${THUMB_MARGIN_START});
+  inline-size: ${THUMB_WIDTH};
+}
+
+#thumb.transitioning {
+  transition: all linear 0.1s;
+}
+
+:host([on]) #thumb {
+  border: 1px solid ${COLOR_ON};
+  margin-inline-start: calc(0px - ${THUMB_WIDTH} - ${THUMB_MARGIN_END});
+}
+
+#track {
+  block-size: 100%;
+  border-radius: ${TRACK_RADIUS};
+  border: ${TRACK_BORDER_WIDTH} solid #dddddd;
+  box-shadow: 0 0 0 1px #f8f8f8;
+  box-sizing: border-box;
+  display: inline-block;
+  inline-size: 100%;
+  overflow: hidden;
+  padding: 0px;
+}
+
+#trackFill {
+  background: ${COLOR_ON};
+  block-size: 100%;
+  border-radius: calc(${TRACK_RADIUS}) - ${TRACK_BORDER_WIDTH});
+  box-shadow: none;
+  box-sizing: border-box;
+  display: inline-block;
+  inline-size: 0%;
+  vertical-align: top;
+}
+
+#trackFill.transitioning {
+  transition: all linear 0.1s;
+}
+
+:host([on]) #track {
+  border: ${TRACK_BORDER_WIDTH} solid ${COLOR_ON};
+}
+
+:host(:focus) {
+  outline-offset: 4px;
+}
+
+:host(:focus) #track {
+  box-shadow: 0 0 0 2px #f8f8f8;
+}
+
+:host([on]:focus) #track {
+  box-shadow: 0 0 0 2px #dddddd;
+}
+
+:host(:focus) #thumb {
+  border: 2px solid black;
+}
+
+:host([on]:focus) #thumb {
+  border: 2px solid ${COLOR_ON};
+}
+
+:host(:not(:focus-visible):focus) {
+  outline: none;
+}
+
+:host(:not(:disabled):not([disabled]):hover) #thumb {
+  inline-size: 26px;
+}
+
+:host([on]:not(:disabled):not([disabled]):hover) #thumb {
+  margin-inline-start: calc(0px - 26px - ${THUMB_MARGIN_END});
+}
+
+:host(:active) #track {
+  background: #dddddd;
+}
+
+:host([on]:active) #track {
+  border: 2px solid #77bbff;
+  box-shadow: 0 0 0 2px #f8f8f8;
+}
+
+:host([on]:active) #trackFill {
+  background: #77bbff;
+}
+
+:host(:disabled), :host([disabled]) {
+  opacity: 0.38;
+}
+
+/*
+ * display:inline-block in the :host ruleset overrides 'hidden' handling
+ * by the user agent.
+ */
+:host([hidden]) {
+  display: none;
+}
+
+`], { type: 'text/css' }));
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = url;
+    return link;
+  };
+}
+
+export function markTransition(element) {
+  element.classList.add('transitioning');
+}
+
+export function unmarkTransition(element) {
+  element.classList.remove('transitioning');
+}

--- a/demo/std-switch-polyfill/track.mjs
+++ b/demo/std-switch-polyfill/track.mjs
@@ -1,0 +1,68 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export class SwitchTrack {
+  /**
+   * @param {!Document} factory A factory for elements created for this track.
+   */
+  constructor(factory) {
+    this._value = false;
+    this._initializeDOM(factory);
+  }
+
+  /**
+   * @return {!Element}
+   */
+  get element() {
+    return this._trackElement;
+  }
+
+  /**
+   * @param {Boolean} newValue
+   */
+  set value(newValue) {
+    const oldValue = this._value;
+    this._value = Boolean(newValue);
+
+    const bar = this._fillElement;
+    if (bar) {
+      bar.style.inlineSize = this._value ? '100%' : '0%';
+      if (oldValue !== this._value) {
+        this._addSlot();
+      }
+    }
+  }
+
+  /**
+   * @param {!Document} factory A factory for elements created for this track.
+   */
+  _initializeDOM(factory) {
+    this._trackElement = factory.createElement('div');
+    this._trackElement.id = 'track';
+    this._fillElement = factory.createElement('span');
+    this._fillElement.id = 'trackFill';
+    this._trackElement.appendChild(this._fillElement);
+    this._slotElement = factory.createElement('slot');
+    this._addSlot();
+
+    if ('part' in HTMLElement.prototype) {
+      this._trackElement.part.add('track');
+      this._fillElement.part.add('track-fill');
+    }
+  }
+
+  /**
+   * Add the <slot>
+   *   - next to _fillElement if _value is true
+   *   - as a child of _fillElement if _value is false
+   * This behavior is helpful to show text in the track.
+   */
+  _addSlot() {
+    if (this._value) {
+      this._fillElement.appendChild(this._slotElement);
+    } else {
+      this._trackElement.appendChild(this._slotElement);
+    }
+  }
+}

--- a/demo/sticky.html
+++ b/demo/sticky.html
@@ -1,72 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <title>Virtual Scoller Demo - Nested sections and sticky</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+  <title>Virtual Scoller Demo - Nested sections and sticky</title>
 
+  <link rel="stylesheet" href="styles.css">
   <style>
-    body {
-      font-family: Roboto, Helvetica, sans-serif;
-      max-width: 600px;
-      height: 100vh;
-      margin: 0px auto;
-      display: flex;
-      flex-direction: column;
-    }
+  section > h1 {
+    font-size: 40pt;
+    position: sticky;
+    top: 0;
+    background: white;
+    opacity: 0.9;
+    z-index: 1;
+  }
 
-    scrollContainer > virtual-scroller {
-      flex: 1;
-      margin: 10px 0;
-      border-top: 2px solid #eee;
-      border-bottom: 2px solid #eee;
-    }
+  .compact contact-element {
+    height: 40px;
+    font-size: 80%;
+    font-weight: bold;
+    font-style: italic;
+    padding: 0 !important;
+  }
 
-    contact-element {
-      contain: style layout;
-    }
-
-    contact-element,
-    button {
-      height: 80px;
-    }
-    section > h1 {
-        font-size: 40pt;
-        position: sticky;
-        top: 0;
-        background: white;
-        opacity: 0.9;
-        z-index: 1;
-    }
-
-    .compact contact-element {
-      height: 40px;
-      font-size: 80%;
-      font-weight: bold;
-      font-style: italic;
-      padding: 0 !important;
-    }
-
-    .resize {
-        animation-direction: alternate;
-        animation-duration: 1s;
-        animation-iteration-count: infinite;
-        animation-timing-function: linear;
-        animation-name: resize;
-        border-style: solid;
-    }
-    @keyframes resize {
-        0% { width: 50%; }
-        100% { width: 100%; }
-    }
-    .scroller {
-        overflow: scroll;
-    }
+  .perf-demo-mode {
+    animation-direction: alternate;
+    animation-duration: 1s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+    animation-name: resize;
+    border-style: solid;
+    overflow: scroll;
+  }
+  @keyframes resize {
+    0% { width: 50%; }
+    100% { width: 100%; }
+  }
   </style>
-</head>
 
-<body>
+  <script type="importmap">
+  {
+    "imports": {
+      "./std-switch-polyfill/std-switch.mjs": [
+        "std:elements/switch",
+        "./std-switch-polyfill/std-switch.mjs"
+      ]
+    }
+  }
+  </script>
+
   <confirm-features></confirm-features>
 
   <p>Demonstrates using nested <code>&lt;virtual-scroller&gt;</code>
@@ -80,11 +62,20 @@
     most of the contacts are display-locked.
   </p>
 
-  <div>
-    <button id=swapButton>switch virtual-scroller &lt;-&gt; div</button>
-    <button id=perfDemoModeButton>performance demo mode</button>
-    <button id=toggleCompactMode>Toggle Compact Mode With Prejudice</button>
-  </div>
+  <fieldset>
+    <label>
+      <std-switch id="useVirtualScroller" on></std-switch>
+      Use <code>&lt;virtual-scroller&gt;</code> instead of <code>&lt;div&gt;</code>
+    </label>
+    <label>
+      <std-switch id="perfDemoMode"></std-switch>
+      Performance demo mode
+    </label>
+    <label>
+      <std-switch id="compactMode"></std-switch>
+      Compact mode
+    </label>
+  </fieldset>
 
   <fps-display hidden></fps-display>
   <div id=scrollContainer>
@@ -92,6 +83,7 @@
   </div>
 
   <script type="module">
+    import './std-switch-polyfill/std-switch.mjs';
     import './util/confirm-features.mjs';
     import './util/fps-display.mjs';
     import './contacts/contact-element.mjs';
@@ -148,6 +140,12 @@
       return section;
     }
 
+    const useVirtualScroller = document.querySelector('#useVirtualScroller');
+    const perfDemoMode = document.querySelector('#perfDemoMode');
+    const compactMode = document.querySelector('#compactMode');
+
+    document.querySelector('confirm-features').associateSwitch(useVirtualScroller);
+
     /*
      * Swap all of the elements in scrollers from virtual-scroller to div or
      * back.
@@ -155,39 +153,29 @@
     function swapScrollers() {
       const newScrollers = [];
       for (const scroller of scrollers) {
-        const swapInLocalName = scroller.localName === 'div' ? 'virtual-scroller' : 'div';
+        const swapInLocalName = useVirtualScroller.on ? 'virtual-scroller' : 'div';
         const swapIn = document.createElement(swapInLocalName);
         util.swapElement(scroller, swapIn);
         newScrollers.push(swapIn);
       }
       scrollers = newScrollers;
     }
-    document.querySelector('#swapButton')
-        .addEventListener('click', swapScrollers);
-
-    let isInperfDemoMode = false;
+    useVirtualScroller.addEventListener('change', swapScrollers);
 
     /**
      * Swaps between performance demo mode and not. In this mode we
      * show the FPS and we do an animated resize of the contacts list.
      */
     function togglePerfDemoMode() {
-      isInperfDemoMode = !isInperfDemoMode;
       document.querySelector('fps-display').toggleAttribute(
-        "hidden", !isInperfDemoMode);
-      document.querySelector('#scrollContainer').className =
-        isInperfDemoMode ? "scroller resize" : ""
+        'hidden', !perfDemoMode.on);
+      document.querySelector('#scrollContainer').classList.toggle(
+        'perf-demo-mode', perfDemoMode.on);
     }
-    document.querySelector('#perfDemoModeButton')
-        .addEventListener('click', togglePerfDemoMode);
+    perfDemoMode.addEventListener('change', togglePerfDemoMode);
 
     function toggleCompactMode() {
-      document.body.classList.toggle('compact');
+      document.body.classList.toggle('compact', compactMode.on);
     }
-    document.querySelector('#toggleCompactMode')
-        .addEventListener('click', toggleCompactMode);
-
+    compactMode.addEventListener('change', toggleCompactMode);
   </script>
-</body>
-
-</html>

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -1,0 +1,24 @@
+body {
+  font-family: Roboto, Helvetica, sans-serif;
+  max-width: 600px;
+  height: 100vh;
+  margin: 0px auto;
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  display: block;
+  margin: 1em;
+}
+
+#scroller {
+  flex: 1;
+  margin: 10px 0;
+  border-top: 2px solid #eee;
+  border-bottom: 2px solid #eee;
+}
+
+contact-element {
+  height: 80px;
+}

--- a/demo/util/confirm-features.mjs
+++ b/demo/util/confirm-features.mjs
@@ -24,6 +24,18 @@ class ConfirmFeatures extends HTMLElement {
       });
     }
   }
+
+  associateSwitch(switchElement) {
+    const hasVirtualScroller = customElements.get('virtual-scroller');
+
+    switchElement.disabled = !hasVirtualScroller;
+    switchElement.on = hasVirtualScroller;
+
+    customElements.whenDefined('virtual-scroller').then(() => {
+      switchElement.disabled = false;
+      switchElement.on = true;
+    });
+  }
 }
 
 customElements.define('confirm-features', ConfirmFeatures);


### PR DESCRIPTION
This updates the loadmore.html and sticky.html demos (currently the prettiest demos) to use a `<std-switch>` element, polyfilled if necessary. The switch will be disabled and locked into the off position on browsers that do not support `<virtual-scroller>`.

The polyfill will eventually live in its own repository, but for now we inline it here.

Other changes:

* Fixes some incorrect CSS selectors
* Moves common styles to styles.css
* Cleans up unnecessary HTML tags
* Fixes a bug where you could never swap back to a `<virtual-scroller>` after swapping to a `<div>` in loadmore.html
* Consolidates scroller and resize classes into perf-demo-mode in sticky.html, since they were always used together

![image](https://user-images.githubusercontent.com/617481/64847252-9149cb80-d649-11e9-9808-ae8fda613b3d.png)
